### PR TITLE
env: 코드 소유자 정보를 명시하기 위해 CODEOWNERS 설정 파일을 추가한다

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mash-up-kr/GSS-Web


### PR DESCRIPTION
<!--
## For Maintainers
- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

### What?

- CODEOWNERS 파일을 통해 해당 레포에 대한 코드 소유자 정보를 GSS-Web팀으로 명시한다.

### Why?

- 명시적으로 해당 레포에 대한 소유자이며 쓰기 권한이 있다는것을 명시하기 위해
- auto assign reviewers, auto assign assignee 기능 활용을 위해

### How?

- CODEOWNERS 파일에 `@org/team` 형식으로 `@mash-up-kr/GSS-Web`을 명시
- mash-up-kr/GSS-Web에서는 해당 레포에 접근할 수 있도록 Maintain 권한 부여

### Check List

- [x] Merge 할 브랜치가 올바른가?