### PR TITLE
feat: 정적 자원 도메인 추가 

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
   images: {
     domains: ['static.dev-oops.kr'],
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   /* config options here */
+  images: {
+    domains: ['static.dev-oops.kr'],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
<!--
* docs: Pull Requst Template md 파일을 추가한다

next.js의 PR Template을 참고하여 우리 프로젝트의 상황에 맞는 항목만 남겨두었습니다.
https://github.com/vercel/next.js/blob/canary/.github/pull_request_template.md?plain=1

* docs: pr template에 존재하는 heading 레벨을 한 단계씩 올린다<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

- S3, CloudFront를 이용해 정적 자원 배포용 AWS 환경을 구축함에 따라 도메인을 `next.config.ts`에 추가해 두었습니다.

## Why?

- `next/image` 컴포넌트의 **이미지 최적화 기능**과 **보안** 등의 이유로 `images.domains`를 통해 사용할 정적 자원 도메인을 지정해 둡니다.

## How?

- `images.domains`에 정적 자원 도메인(static.dev-oops.kr)을 추가해두었습니다.

## Check List

- [x] Merge 할 브랜치가 올바른가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 외부 이미지 도메인에 'static.dev-oops.kr'을 추가하여 이미지 최적화 및 로딩이 가능하도록 설정이 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->