### PR TITLE
feat: `Tabs` 컴포넌트 제작

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,7 +57,8 @@
     "no-use-before-define": "off",
     "react/react-in-jsx-scope": "off",
     "better-tailwindcss/no-unregistered-classes": "off",
-    "react/button-has-type": "off"
+    "react/button-has-type": "off",
+    "@typescript-eslint/no-unused-vars": "error"
   },
   "ignorePatterns": ["node_modules/"]
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss';
 @import '../styles/colors.css';
 @import '../styles/typography.css';
+@import '../styles/tabs.css';
 
 :root {
   --background: #14151a;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,59 @@
+import { Tabs } from '@/components/common/Tabs/Tabs';
+import { TabsContent } from '@/components/common/Tabs/TabsContent';
+import { TabsList } from '@/components/common/Tabs/TabsList';
+import { TabsTrigger } from '@/components/common/Tabs/TabsTrigger';
+
 export default function Home() {
-  return <div>{'Home'}</div>;
+  return (
+    <div className={'flex flex-col gap-8 p-8'}>
+      <div className={'p-8'}>
+        <h1 className={'text-2xl font-bold'}>{'Tabs Medium'}</h1>
+        <div>
+          <Tabs defaultValue={'전체'} className={'w-[400px]'}>
+            <TabsList>
+              <TabsTrigger value={'전체'}>{'전체'}</TabsTrigger>
+              <TabsTrigger value={'레포1'}>{'레포1'}</TabsTrigger>
+              <TabsTrigger value={'레포2'} disabled>
+                {'레포2'}
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value={'전체'} className={'p-4'}>
+              <h3 className={'mb-4 text-lg font-medium'}>{'Account Settings'}</h3>
+              <p className={'text-gray-300'}>{'Make changes to your account here.'}</p>
+            </TabsContent>
+            <TabsContent value={'레포1'} className={'p-4'}>
+              <h3 className={'mb-4 text-lg font-medium'}>{'Password Settings'}</h3>
+              <p className={'text-gray-300'}>{'Change your password here.'}</p>
+            </TabsContent>
+          </Tabs>
+        </div>
+      </div>
+      <div className={'p-8'}>
+        <h1 className={'text-2xl font-bold'}>{'Tabs Large'}</h1>
+        <div>
+          <Tabs defaultValue={'전체'} className={'w-[400px]'}>
+            <TabsList>
+              <TabsTrigger value={'전체'} size={'large'}>
+                {'전체'}
+              </TabsTrigger>
+              <TabsTrigger value={'레포1'} size={'large'}>
+                {'레포1'}
+              </TabsTrigger>
+              <TabsTrigger value={'레포2'} size={'large'} disabled>
+                {'레포2'}
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value={'전체'} className={'p-4'}>
+              <h3 className={'mb-4 text-lg font-medium'}>{'Account Settings'}</h3>
+              <p className={'text-gray-300'}>{'Make changes to your account here.'}</p>
+            </TabsContent>
+            <TabsContent value={'레포1'} className={'p-4'}>
+              <h3 className={'mb-4 text-lg font-medium'}>{'Password Settings'}</h3>
+              <p className={'text-gray-300'}>{'Change your password here.'}</p>
+            </TabsContent>
+          </Tabs>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,3 @@
-import Button from '@/components/common/Button/Button';
-
-function PlusIcon() {
-  return (
-    <svg width={'16'} height={'16'} viewBox={'0 0 16 16'} fill={'currentColor'}>
-      <path d={'M8 1v14M1 8h14'} stroke={'currentColor'} strokeWidth={'2'} strokeLinecap={'round'} />
-    </svg>
-  );
-}
-
 export default function Home() {
   return <div>{'Home'}</div>;
 }

--- a/src/components/common/Tabs/Tabs.tsx
+++ b/src/components/common/Tabs/Tabs.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useState, useRef, ReactNode, useMemo } from 'react';
+
+import { TabsContext } from '@/providers/TabsContext';
+
+interface TabsProps {
+  defaultValue: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function Tabs({ defaultValue, children, className = '' }: TabsProps) {
+  const [activeTab, setActiveTab] = useState(defaultValue);
+  const tabRefs = useRef(new Map<string, HTMLButtonElement>());
+
+  const registerTab = (value: string, element: HTMLButtonElement | null) => {
+    if (element) {
+      tabRefs.current.set(value, element);
+    } else {
+      tabRefs.current.delete(value);
+    }
+  };
+
+  const contextValue = useMemo(
+    () => ({
+      activeTab,
+      setActiveTab,
+      registerTab,
+      tabElements: tabRefs.current,
+    }),
+    [activeTab],
+  );
+
+  return (
+    <TabsContext.Provider value={contextValue}>
+      <div
+        className={`
+          ${className}
+        `}
+      >
+        {children}
+      </div>
+    </TabsContext.Provider>
+  );
+}

--- a/src/components/common/Tabs/TabsContent.tsx
+++ b/src/components/common/Tabs/TabsContent.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+import { useTabsContext } from '@/providers/TabsContext';
+
+interface TabsContentProps {
+  value: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function TabsContent({ value, children, className = '' }: TabsContentProps) {
+  const { activeTab } = useTabsContext();
+
+  if (activeTab !== value) return null;
+
+  return (
+    <div role={'tabpanel'} className={className}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/common/Tabs/TabsList.tsx
+++ b/src/components/common/Tabs/TabsList.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+
+interface TabsListProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export function TabsList({ children, className = '' }: TabsListProps) {
+  return (
+    <div
+      role={'tablist'}
+      className={`
+        inset-shadow-tabs-list
+        ${className}
+      `}
+    >
+      <div className={'flex'}>{children}</div>
+    </div>
+  );
+}

--- a/src/components/common/Tabs/TabsTrigger.tsx
+++ b/src/components/common/Tabs/TabsTrigger.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { cva, type VariantProps } from 'class-variance-authority';
+import { HTMLAttributes, ReactNode } from 'react';
+
+import { useTabsContext } from '@/providers/TabsContext';
+import { cn } from '@/utils/cn';
+
+interface TabsTriggerProps extends VariantProps<typeof tabsTriggerVariants> {
+  value: string;
+  children: ReactNode;
+  className?: string;
+  disabled?: boolean;
+}
+
+const tabsTriggerVariants = cva('flex cursor-pointer gap-2 font-medium', {
+  variants: {
+    size: {
+      medium: 'text-body-small px-3.5 pt-1 pb-3',
+      large: 'text-body-large px-8 pt-1 pb-3.5',
+    },
+  },
+  defaultVariants: {
+    size: 'medium',
+  },
+});
+
+const TABS_TRIGGER_ACTIVE_STYLES: HTMLAttributes<HTMLButtonElement>['className'] =
+  'enabled:text-on-surface-high enabled:inset-shadow-tabs-active enabled:font-semibold';
+const TABS_TRIGGER_HOVER_STYLES: HTMLAttributes<HTMLButtonElement>['className'] =
+  'hover:enabled:text-dark-grey-700 hover:enabled:inset-shadow-tabs-hover';
+const TABS_TRIGGER_ENABLED_STYLES: HTMLAttributes<HTMLButtonElement>['className'] =
+  'enabled:text-shadow-on-surface-lowest enabled:inset-shadow-tabs-enabled';
+const TABS_TRIGGER_DISABLED_STYLES: HTMLAttributes<HTMLButtonElement>['className'] =
+  'disabled:text-dark-grey-300 disabled:cursor-not-allowed';
+
+export function TabsTrigger({ value, children, size, className = '', disabled = false }: TabsTriggerProps) {
+  const { activeTab, setActiveTab, registerTab } = useTabsContext();
+  const isActive = activeTab === value;
+
+  const handleClick = () => {
+    if (!disabled) {
+      setActiveTab(value);
+    }
+  };
+
+  return (
+    <button
+      role={'tab'}
+      type={'button'}
+      ref={(el) => registerTab(value, el)}
+      onClick={handleClick}
+      aria-selected={isActive}
+      className={cn(
+        tabsTriggerVariants({ size }),
+        isActive
+          ? `
+            ${TABS_TRIGGER_ACTIVE_STYLES}
+          `
+          : `
+            ${TABS_TRIGGER_ENABLED_STYLES}
+            ${TABS_TRIGGER_HOVER_STYLES}
+          `,
+        disabled && TABS_TRIGGER_DISABLED_STYLES,
+        className,
+      )}
+      disabled={disabled}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/providers/TabsContext.tsx
+++ b/src/providers/TabsContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+
+export interface TabsContextType {
+  activeTab: string;
+  setActiveTab: (value: string) => void;
+  registerTab: (value: string, element: HTMLButtonElement | null) => void;
+  tabElements: Map<string, HTMLButtonElement>;
+}
+
+export const TabsContext = createContext<TabsContextType | null>(null);
+
+export const useTabsContext = () => {
+  const context = useContext(TabsContext);
+  if (!context) {
+    throw new Error('Tabs components must be used within a Tabs provider');
+  }
+  return context;
+};

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -57,6 +57,7 @@
   --color-surface: var(--color-dark-grey-0);
   --color-surface-container-lowest: var(--color-dark-grey-50);
   --color-surface-container: var(--color-dark-grey-100);
+  --color-on-surface-high: var(--color-dark-grey-800);
   --color-on-surface-highest: var(--color-dark-grey-900);
   --color-on-surface: var(--color-dark-grey-800);
   --color-on-surface-low: var(--color-dark-grey-600);

--- a/src/styles/tabs.css
+++ b/src/styles/tabs.css
@@ -1,5 +1,8 @@
 @import './colors.css';
 
 @theme {
+  --inset-shadow-tabs-active: inset 0 -2px 0 var(--color-primary);
+  --inset-shadow-tabs-hover: inset 0 -1px 0 var(--color-dark-grey-700);
+  --inset-shadow-tabs-enabled: inset 0 -1px 0 var(--color-dark-grey-100);
   --inset-shadow-tabs-list: inset 0 -1px 0 var(--color-dark-grey-100);
 }

--- a/src/styles/tabs.css
+++ b/src/styles/tabs.css
@@ -1,0 +1,5 @@
+@import './colors.css';
+
+@theme {
+  --inset-shadow-tabs-list: inset 0 -1px 0 var(--color-dark-grey-100);
+}


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

- figma에 명시된 대로 `Tabs` 컴포넌트를 제작했습니다. 
	- 네이밍 및 구성 방식은 [shadcn-tabs](https://ui.shadcn.com/docs/components/tabs)의 usage를 참고 했습니다.
	- 컴포넌트 구조는 4개의 주요 컴포넌트로 구성되어 있습니다.
		- `Tabs`: 루트 컨테이너 및 Context Provider
		- `TabsList`: 탭 버튼들을 감싸는 컨테이너
		- `TabsTrigger`: 개별 탭 버튼
		- `TabsContent`: 탭 별 콘텐츠 패널
	- 사용방법은 아래와 같습니다.
		```jsx
		<Tabs defaultValue={'전체'}>
			<TabsList>
				<TabsTrigger value={'전체'}>{'전체'}</TabsTrigger>
				<TabsTrigger value={'레포1'}>{'레포1'}</TabsTrigger>
				<TabsTrigger value={'레포2'} disabled>{'레포2'}</TabsTrigger>
			</TabsList>
			<TabsContent value={'전체'} className={'p-4'}>
				{/*콘텐츠 내용*/}
			</TabsContent>
			<TabsContent value={'레포1'} className={'p-4'}>
				{/*콘텐츠 내용*/}
			</TabsContent>
		</Tabs>
		```
- 개인적으로 `provider`와 `colors` 폴더 구조를 어떻게 깔끔하게 들고갈지.. 이대로 괜찮을지에 대한 고민이 있습니다,, 😅
- 예시 코드는 merge 하기 전 지우고 develop에 올리겠습니다,,ㅎ 올릴 필요 없어 보여서..ㅎㅎ
## Why?

- 여러 콘텐츠를 쉽게 전환할 수 있는 Tabs UI 컴포넌트가 필요해서 제작했습니다.

## How?

|<video src="https://github.com/user-attachments/assets/91f5ef58-7677-4378-a1f5-4973aa1f7c2d" />|
|:---:|
| Tabs 시현 영상|

## Check List

- [x] Merge 할 브랜치가 올바른가?
