### PR TITLE
feat: 회고 상세 페이지 UI를 구현한다

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,6 +57,7 @@
     "no-use-before-define": "off",
     "react/react-in-jsx-scope": "off",
     "better-tailwindcss/no-unregistered-classes": "off",
+    "better-tailwindcss/enforce-consistent-line-wrapping": "off",
     "react/button-has-type": "off",
     "@typescript-eslint/no-unused-vars": "error"
   },

--- a/src/app/retrospective/[pullRequestId]/layout.tsx
+++ b/src/app/retrospective/[pullRequestId]/layout.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function RetrospectiveLayout({ children }: { children: React.ReactNode }) {
+  return <div className={'px-[40px] pt-[68px]'}>{children}</div>;
+}

--- a/src/app/retrospective/[pullRequestId]/layout.tsx
+++ b/src/app/retrospective/[pullRequestId]/layout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
 export default function RetrospectiveLayout({ children }: { children: React.ReactNode }) {
-  return <div className={'px-[40px] pt-[68px]'}>{children}</div>;
+  return <div className={'px-[40px] pt-[68px] pb-[132px]'}>{children}</div>;
 }

--- a/src/app/retrospective/[pullRequestId]/page.tsx
+++ b/src/app/retrospective/[pullRequestId]/page.tsx
@@ -1,4 +1,5 @@
 import PullRequestSummary from '@/components/retrospective/PullRequestSummary';
+import RetrospectiveAnswers from '@/components/retrospective/RetrospectiveAnswers';
 import RetrospectiveHeader from '@/components/retrospective/RetrospectiveHeader';
 import RetrospectiveQuestions from '@/components/retrospective/RetrospectiveQuestions';
 
@@ -9,6 +10,7 @@ export default function RetrospectivePage() {
       <main className={'flex flex-col gap-[68px]'}>
         <PullRequestSummary />
         <RetrospectiveQuestions />
+        <RetrospectiveAnswers />
       </main>
     </>
   );

--- a/src/app/retrospective/[pullRequestId]/page.tsx
+++ b/src/app/retrospective/[pullRequestId]/page.tsx
@@ -1,5 +1,6 @@
 import PullRequestSummary from '@/components/retrospective/PullRequestSummary';
 import RetrospectiveHeader from '@/components/retrospective/RetrospectiveHeader';
+import RetrospectiveQuestions from '@/components/retrospective/RetrospectiveQuestions';
 
 export default function RetrospectivePage() {
   return (
@@ -7,6 +8,7 @@ export default function RetrospectivePage() {
       <RetrospectiveHeader />
       <main className={'flex flex-col gap-[68px]'}>
         <PullRequestSummary />
+        <RetrospectiveQuestions />
       </main>
     </>
   );

--- a/src/app/retrospective/[pullRequestId]/page.tsx
+++ b/src/app/retrospective/[pullRequestId]/page.tsx
@@ -1,3 +1,4 @@
+import FixedFooter from '@/components/retrospective/FixedFooter';
 import PullRequestSummary from '@/components/retrospective/PullRequestSummary';
 import RetrospectiveAnswers from '@/components/retrospective/RetrospectiveAnswers';
 import RetrospectiveHeader from '@/components/retrospective/RetrospectiveHeader';
@@ -7,11 +8,14 @@ export default function RetrospectivePage() {
   return (
     <>
       <RetrospectiveHeader />
+
       <main className={'flex flex-col gap-[68px]'}>
         <PullRequestSummary />
         <RetrospectiveQuestions />
         <RetrospectiveAnswers />
       </main>
+
+      <FixedFooter />
     </>
   );
 }

--- a/src/app/retrospective/[pullRequestId]/page.tsx
+++ b/src/app/retrospective/[pullRequestId]/page.tsx
@@ -1,10 +1,13 @@
+import PullRequestSummary from '@/components/retrospective/PullRequestSummary';
 import RetrospectiveHeader from '@/components/retrospective/RetrospectiveHeader';
 
 export default function RetrospectivePage() {
   return (
     <>
       <RetrospectiveHeader />
-      <main />
+      <main className={'flex flex-col gap-[68px]'}>
+        <PullRequestSummary />
+      </main>
     </>
   );
 }

--- a/src/app/retrospective/[pullRequestId]/page.tsx
+++ b/src/app/retrospective/[pullRequestId]/page.tsx
@@ -1,0 +1,10 @@
+import RetrospectiveHeader from '@/components/retrospective/RetrospectiveHeader';
+
+export default function RetrospectivePage() {
+  return (
+    <>
+      <RetrospectiveHeader />
+      <main />
+    </>
+  );
+}

--- a/src/components/retrospective/FixedFooter.tsx
+++ b/src/components/retrospective/FixedFooter.tsx
@@ -1,0 +1,15 @@
+import Button from '../common/Button';
+
+export default function FixedFooter() {
+  return (
+    <footer
+      className={
+        'fixed bottom-0 left-[50%] flex w-full max-w-[840px] -translate-x-1/2 justify-end bg-[linear-gradient(180deg,_rgba(20,22,26,0)_0%,_#14161A_48.11%)] px-[40px] pt-[80px] pb-[12px] bg-[background:'
+      }
+    >
+      <Button variant={'filledPrimary'} size={'medium'} disabled>
+        {'회고완료'}
+      </Button>
+    </footer>
+  );
+}

--- a/src/components/retrospective/PullRequestSummary.tsx
+++ b/src/components/retrospective/PullRequestSummary.tsx
@@ -1,0 +1,51 @@
+const DUMMY_SUMMARY = [
+  {
+    title: 'Redis 사용 설정',
+    content: ['GitHub Actions에 Redis 실행 단계 추가'],
+  },
+  {
+    title: 'RedisTemplate 설정 추가',
+    content: ['Redis에 문자열 기반으로 데이터를 저장/조회할 수 있게 설정'],
+  },
+  {
+    title: 'Redis 키 만료 이벤트 리스너 설정',
+    content: ['"__keyevent@0__:expired" 채널 구독하도록 설정', 'Spring Redis의 RedisMessageListenerContainer 사용'],
+  },
+  {
+    title: '만료 이벤트 처리 리스너 구현',
+    content: [
+      'Redis에서 특정 키가 만료되면 메시지 수신',
+      '이벤트 종류(EVENT_OPEN, VOTE_OPEN)에 따라 다음 상태로 전이할 준비 (TODO로 처리 예정)',
+      '향후 Spring 이벤트로 전파 예정 (의존성 분리 목적)',
+    ],
+  },
+];
+
+export default function PullRequestSummary() {
+  return (
+    <section className={'flex flex-col gap-[20px] pt-[36px]'}>
+      <div className={'flex flex-col items-start justify-start gap-[8px]'}>
+        {'요약 아이콘'}
+        <div className={'flex flex-col gap-[2px]'}>
+          <span className={'text-h4 font-semibold'}>{'AI 요약'}</span>
+          <span className={'text-body-medium font-regular text-on-surface-lowest'}>
+            {'이번 PR에서 작업한 내용이에요.'}
+          </span>
+        </div>
+      </div>
+
+      <div className={'bg-dark-grey-50 align-start flex flex-col justify-start gap-[20px] rounded-[8px] p-[24px]'}>
+        {DUMMY_SUMMARY.map((summary) => (
+          <div className={'flex flex-col gap-[4px]'}>
+            <span className={'text-body-medium font-semibold'}>{summary.title}</span>
+            <ul className={'flex flex-col gap-[4px]'}>
+              {summary.content.map((content) => (
+                <li className={'text-body-small font-regular text-on-surface-lowest'}>{content}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/retrospective/PullRequestSummary.tsx
+++ b/src/components/retrospective/PullRequestSummary.tsx
@@ -1,3 +1,5 @@
+import SectionHeader from './SectionHeader';
+
 const DUMMY_SUMMARY = [
   {
     title: 'Redis 사용 설정',
@@ -24,15 +26,11 @@ const DUMMY_SUMMARY = [
 export default function PullRequestSummary() {
   return (
     <section className={'flex flex-col gap-[20px] pt-[36px]'}>
-      <div className={'flex flex-col items-start justify-start gap-[8px]'}>
-        {'요약 아이콘'}
-        <div className={'flex flex-col gap-[2px]'}>
-          <span className={'text-h4 font-semibold'}>{'AI 요약'}</span>
-          <span className={'text-body-medium font-regular text-on-surface-lowest'}>
-            {'이번 PR에서 작업한 내용이에요.'}
-          </span>
-        </div>
-      </div>
+      <SectionHeader
+        title={'AI 요약'}
+        description={'이번 PR에서 작업한 내용이에요.'}
+        icon={<span>{'요약 아이콘'}</span>}
+      />
 
       <div className={'bg-dark-grey-50 align-start flex flex-col justify-start gap-[20px] rounded-[8px] p-[24px]'}>
         {DUMMY_SUMMARY.map((summary) => (

--- a/src/components/retrospective/PullRequestSummary.tsx
+++ b/src/components/retrospective/PullRequestSummary.tsx
@@ -34,11 +34,13 @@ export default function PullRequestSummary() {
 
       <div className={'bg-dark-grey-50 align-start flex flex-col justify-start gap-[20px] rounded-[8px] p-[24px]'}>
         {DUMMY_SUMMARY.map((summary) => (
-          <div className={'flex flex-col gap-[4px]'}>
+          <div className={'flex flex-col gap-[4px]'} key={summary.title}>
             <span className={'text-body-medium font-semibold'}>{summary.title}</span>
             <ul className={'flex flex-col gap-[4px]'}>
-              {summary.content.map((content) => (
-                <li className={'text-body-small font-regular text-on-surface-lowest'}>{content}</li>
+              {summary.content.map((content, index) => (
+                <li className={'text-body-small font-regular text-on-surface-lowest'} key={index}>
+                  {content}
+                </li>
               ))}
             </ul>
           </div>

--- a/src/components/retrospective/RetrospectiveAnswers.tsx
+++ b/src/components/retrospective/RetrospectiveAnswers.tsx
@@ -1,0 +1,22 @@
+import SectionHeader from './SectionHeader';
+
+export default function RetrospectiveAnswers() {
+  return (
+    <section className={'flex flex-col gap-[20px]'}>
+      <SectionHeader
+        title={'PR 회고'}
+        description={'선택한 질문을 바탕으로 이번 작업을 회고해보세요.'}
+        icon={<span>{'펜 아이콘'}</span>}
+      />
+
+      <div
+        className={
+          'border-outline flex items-center justify-start gap-[8px] rounded-[8px] border-[1px] px-[24px] py-[16px]'
+        }
+      >
+        <span>{'경고 아이콘'}</span>
+        <span>{'아직 질문을 고르지 않았어요.'}</span>
+      </div>
+    </section>
+  );
+}

--- a/src/components/retrospective/RetrospectiveHeader.tsx
+++ b/src/components/retrospective/RetrospectiveHeader.tsx
@@ -1,0 +1,21 @@
+import Tag from '@/components/common/Tag';
+
+export default function RetrospectiveHeader() {
+  return (
+    <header
+      className={'border-outline-variant flex flex-col items-start justify-start gap-[6px] border-b-[1px] pb-[36px]'}
+    >
+      <Tag dotColor={'violet'}>{'feature'}</Tag>
+      <div>
+        <h1 className={'text-h1 font-semibold'}>{'feat: 레디스 이벤트 리스너 구현 #40'}</h1>
+        <div className={'text-body-small text-on-surface-low font-regular flex gap-[8px]'}>
+          <span>{'회고 전'}</span>
+          <span>{'·'}</span>
+          <span>{'Merged on Jul 22, 2024'}</span>
+          <span>{'·'}</span>
+          <span>{'PR 보러가기'}</span>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/retrospective/RetrospectiveQuestions.tsx
+++ b/src/components/retrospective/RetrospectiveQuestions.tsx
@@ -44,12 +44,14 @@ export default function RetrospectiveQuestions() {
 
       <Tabs defaultValue={DUMMY_QUESTIONS[0].category}>
         <TabsList>
-          {DUMMY_QUESTIONS.map(({ category }) => (
-            <TabsTrigger value={category}>{category}</TabsTrigger>
+          {DUMMY_QUESTIONS.map(({ category }, index) => (
+            <TabsTrigger value={category} key={index}>
+              {category}
+            </TabsTrigger>
           ))}
         </TabsList>
-        {DUMMY_QUESTIONS.map(({ category, questions }) => (
-          <TabsContent value={category} className={'flex flex-col items-end gap-[20px] pt-[20px]'}>
+        {DUMMY_QUESTIONS.map(({ category, questions }, index) => (
+          <TabsContent value={category} className={'flex flex-col items-end gap-[20px] pt-[20px]'} key={index}>
             <ul className={'flex w-full flex-col gap-[12px]'}>
               {questions.map(({ questionId, question }) => (
                 <div

--- a/src/components/retrospective/RetrospectiveQuestions.tsx
+++ b/src/components/retrospective/RetrospectiveQuestions.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState } from 'react';
+
+import Button from '../common/Button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../common/Tabs';
+
+const DUMMY_QUESTIONS = [
+  {
+    category: 'Redis 활용 전략',
+    questions: [
+      { questionId: 1, question: 'Redis를 도입하게 된 주요 목적은 무엇이었나요?' },
+      { questionId: 2, question: 'Redis를 사용할 때 고려한 성능 이슈가 있었나요?' },
+    ],
+  },
+  {
+    category: 'CI/CD 및 배포',
+    questions: [
+      { questionId: 3, question: 'GitHub Actions에 Redis를 추가할 때 겪은 어려움은 무엇이었나요?' },
+      { questionId: 4, question: 'CI/CD 파이프라인에서 Redis를 효과적으로 관리하는 방법은 무엇인가요?' },
+    ],
+  },
+  {
+    category: 'Spring & Redis 연동',
+    questions: [
+      { questionId: 5, question: 'Spring에서 RedisTemplate을 사용할 때 주의할 점은 무엇인가요?' },
+      { questionId: 6, question: 'RedisMessageListenerContainer를 도입한 이유와 장점은 무엇인가요?' },
+    ],
+  },
+  {
+    category: '이벤트 기반 아키텍처',
+    questions: [
+      { questionId: 7, question: '만료 이벤트 리스너를 구현하면서 얻은 인사이트가 있다면?' },
+      { questionId: 8, question: '향후 이벤트 전파 구조를 개선할 계획이 있나요?' },
+    ],
+  },
+];
+
+export default function RetrospectiveQuestions() {
+  const [currentCategory] = useState(DUMMY_QUESTIONS[0].category);
+
+  return (
+    <section className={'flex flex-col gap-[20px]'}>
+      <div className={'flex flex-col gap-[8px]'}>
+        {'회고 아이콘'}
+        <div className={'flex flex-col gap-[2px]'}>
+          <span className={'text-h4 font-semibold'}>{'AI 생성 회고 질문'}</span>
+          <span className={'text-body-medium font-regular text-on-surface-lowest'}>
+            {'이번 작업에서 회고하고 싶은 질문을 골라보세요.'}
+          </span>
+        </div>
+      </div>
+
+      <Tabs defaultValue={currentCategory}>
+        <TabsList>
+          {DUMMY_QUESTIONS.map(({ category }) => (
+            <TabsTrigger value={category}>{category}</TabsTrigger>
+          ))}
+        </TabsList>
+        {DUMMY_QUESTIONS.map(({ category, questions }) => (
+          <TabsContent value={category} className={'flex flex-col items-end gap-[20px] pt-[20px]'}>
+            <ul className={'flex w-full flex-col gap-[12px]'}>
+              {questions.map(({ questionId, question }) => (
+                <div
+                  className={
+                    'bg-dark-grey-50 bg-dark-grey border-outline flex w-full gap-[28px] rounded-[6px] border-[1px] py-[16px] pr-[12px] pl-[24px]'
+                  }
+                  key={questionId}
+                >
+                  <p className={'grow-1'}>{question}</p>
+                  {/* TODO: 병합 후 addIcon */}
+                  <span>{'+'}</span>
+                </div>
+              ))}
+            </ul>
+
+            <Button size={'tiny'} variant={'outlineGrey'}>
+              {'질문 생성하기'}
+            </Button>
+          </TabsContent>
+        ))}
+      </Tabs>
+    </section>
+  );
+}

--- a/src/components/retrospective/RetrospectiveQuestions.tsx
+++ b/src/components/retrospective/RetrospectiveQuestions.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import SectionHeader from './SectionHeader';
 import Button from '../common/Button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../common/Tabs';
 
@@ -41,15 +42,11 @@ export default function RetrospectiveQuestions() {
 
   return (
     <section className={'flex flex-col gap-[20px]'}>
-      <div className={'flex flex-col gap-[8px]'}>
-        {'회고 아이콘'}
-        <div className={'flex flex-col gap-[2px]'}>
-          <span className={'text-h4 font-semibold'}>{'AI 생성 회고 질문'}</span>
-          <span className={'text-body-medium font-regular text-on-surface-lowest'}>
-            {'이번 작업에서 회고하고 싶은 질문을 골라보세요.'}
-          </span>
-        </div>
-      </div>
+      <SectionHeader
+        title={'AI 생성 회고 질문'}
+        description={'이번 작업에서 회고하고 싶은 질문을 골라보세요.'}
+        icon={<span>{'회고 아이콘'}</span>}
+      />
 
       <Tabs defaultValue={currentCategory}>
         <TabsList>

--- a/src/components/retrospective/RetrospectiveQuestions.tsx
+++ b/src/components/retrospective/RetrospectiveQuestions.tsx
@@ -1,7 +1,3 @@
-'use client';
-
-import { useState } from 'react';
-
 import SectionHeader from './SectionHeader';
 import Button from '../common/Button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../common/Tabs';
@@ -38,8 +34,6 @@ const DUMMY_QUESTIONS = [
 ];
 
 export default function RetrospectiveQuestions() {
-  const [currentCategory] = useState(DUMMY_QUESTIONS[0].category);
-
   return (
     <section className={'flex flex-col gap-[20px]'}>
       <SectionHeader
@@ -48,7 +42,7 @@ export default function RetrospectiveQuestions() {
         icon={<span>{'회고 아이콘'}</span>}
       />
 
-      <Tabs defaultValue={currentCategory}>
+      <Tabs defaultValue={DUMMY_QUESTIONS[0].category}>
         <TabsList>
           {DUMMY_QUESTIONS.map(({ category }) => (
             <TabsTrigger value={category}>{category}</TabsTrigger>

--- a/src/components/retrospective/SectionHeader.tsx
+++ b/src/components/retrospective/SectionHeader.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+interface SectionHeaderProps {
+  title: string;
+  description: string;
+  icon: ReactNode;
+}
+
+export default function SectionHeader({ title, description, icon }: SectionHeaderProps) {
+  return (
+    <div className={'flex flex-col items-start justify-start gap-[8px]'}>
+      {icon}
+      <div className={'flex flex-col gap-[2px]'}>
+        <span className={'text-h4 font-semibold'}>{title}</span>
+        <span className={'text-body-medium font-regular text-on-surface-lowest'}>{description}</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

- 회고 상세 페이지의 단순 UI만을 구현

## Why?

- 백엔드 API가 나오기 전 병렬적 작업 및 UI 작업에 대한 태스크 분리를 위해

## How?

- figma 디자인에 따라 데이터는 모두 정적인 더미 데이터로 UI만을 스타일링

## Check List

- [ ] Merge 할 브랜치가 올바른가?
