### PR TITLE
fix: 페이지네이션 백엔드 명세에 맞게 수정

### DIFF
--- a/src/components/home/RepositoryList.tsx
+++ b/src/components/home/RepositoryList.tsx
@@ -28,7 +28,7 @@ const PAGE_SIZE = 5;
 
 export default function RepositoryList({ repository }: RepositoryListProps) {
   const [pullRequestId, setPullRequestId] = useState<number>();
-  const [currentPage, setCurrentPage] = useState(1);
+  const [currentPage, setCurrentPage] = useState(0);
 
   const { data: PRData, isLoading: isPRDataLoading } = useGetPullRequestsQuery({
     variables: {
@@ -50,7 +50,7 @@ export default function RepositoryList({ repository }: RepositoryListProps) {
   );
 
   const totalPage = Math.ceil((repository.pullRequestCount || 0) / PAGE_SIZE);
-  const { pagesToShow } = usePagination({ totalPage, currentPage });
+  const { pagesToShow } = usePagination({ totalPage, currentPage: currentPage + 1 });
 
   const handlePRItemOver = (pr: RepositoryPullRequestResponseType) => {
     setPullRequestId(pr.id);
@@ -93,7 +93,7 @@ export default function RepositoryList({ repository }: RepositoryListProps) {
             <PaginationItem>
               <PaginationPrevious
                 className={'flex size-10 items-center justify-center rounded-full'}
-                onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 1))}
+                onClick={() => setCurrentPage((prev) => Math.max(prev - 1, 0))}
               />
             </PaginationItem>
 
@@ -105,9 +105,9 @@ export default function RepositoryList({ repository }: RepositoryListProps) {
               ) : (
                 <PaginationItem key={`page-${page}`}>
                   <PaginationLink
-                    isActive={currentPage === page}
-                    onClick={() => setCurrentPage(Number(page))}
-                    className={`text-body-medium flex size-10 cursor-pointer items-center justify-center rounded-full transition-colors duration-100 ease-out ${currentPage === page ? 'bg-dark-grey-50 font-medium' : 'font-regular'}`}
+                    isActive={currentPage === page - 1}
+                    onClick={() => setCurrentPage(Number(page) - 1)}
+                    className={`text-body-medium flex size-10 cursor-pointer items-center justify-center rounded-full transition-colors duration-100 ease-out ${currentPage === page - 1 ? 'bg-dark-grey-50 font-medium' : 'font-regular'}`}
                   >
                     {page}
                   </PaginationLink>
@@ -118,7 +118,7 @@ export default function RepositoryList({ repository }: RepositoryListProps) {
             <PaginationItem>
               <PaginationNext
                 className={'flex size-10 items-center justify-center rounded-full'}
-                onClick={() => setCurrentPage((prev) => Math.min(prev + 1, totalPage))}
+                onClick={() => setCurrentPage((prev) => Math.min(prev + 1, totalPage - 1))}
               />
             </PaginationItem>
           </PaginationContent>

--- a/src/components/landing/Section/FeatureSection.tsx
+++ b/src/components/landing/Section/FeatureSection.tsx
@@ -45,27 +45,32 @@ export default function FeatureSection() {
             </div>
           </FeatureCard>
           <FeatureCard image={LandingSymbol2}>
-            <h3 className={'text-h3'}>{'레포지토리 연동'}</h3>
+            <h3 className={'text-h3'}>{'회고를 돕는 AI'}</h3>
             <div>
               <p className={'text-h5'}>
                 <span className={'blue-tiny-right bg-clip-text font-semibold text-transparent'}>
-                  {'GitHub PR을 자동으로 가져'}
+                  {'PR 내용을 요약'}
                 </span>
-                {'와요.'}
+                {'해주고,'}
               </p>
-              <p>{'회고할 작업을 한눈에 확인할 수 있어요.'}</p>
+              <p className={'text-h5'}>
+                <span className={'blue-tiny-right bg-clip-text font-semibold text-transparent'}>
+                  {'AI가 고민을 꺼내줄 질문'}
+                </span>
+                {'도 던져줘요.'}
+              </p>
             </div>
           </FeatureCard>
           <FeatureCard image={LandingSymbol3}>
-            <h3 className={'text-h3'}>{'레포지토리 연동'}</h3>
+            <h3 className={'text-h3'}>{'질문만 답해서 완료!'}</h3>
             <div>
+              <p className={'text-h5'}>{'부담 없이 한 줄씩 적다 보면'}</p>
               <p className={'text-h5'}>
                 <span className={'blue-tiny-right bg-clip-text font-semibold text-transparent'}>
-                  {'GitHub PR을 자동으로 가져'}
+                  {'중요한 맥락이 자연스럽게 기록'}
                 </span>
-                {'와요.'}
+                {'돼요.'}
               </p>
-              <p>{'회고할 작업을 한눈에 확인할 수 있어요.'}</p>
             </div>
           </FeatureCard>
         </div>


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

- 페이지네이션 백엔드 명세에 맞게 수정
	- 유저한테는 1페이지 이지만 백엔드에는 0으로 들어가야함.

## Why?

-

## How?

-

## Check List

- [x] Merge 할 브랜치가 올바른가?
