### PR TITLE
fix: 상태 결정 로직 개선

### DIFF
--- a/src/app/(with-layout)/retrospective/[pullRequestId]/page.tsx
+++ b/src/app/(with-layout)/retrospective/[pullRequestId]/page.tsx
@@ -142,9 +142,13 @@ export default function RetrospectivePage() {
       answer: null,
     }));
 
+  // 상태 결정 로직 개선: recordStatus가 DONE이거나 isRetrospectiveDone이 true면 무조건 '완료'
   let status: '전' | '중' | '완료' = '전';
-  if (selectedQuestionIds.length > 0) status = '중';
-  if (isRetrospectiveDone) status = '완료';
+  if (rawData?.data?.recordStatus === 'DONE' || isRetrospectiveDone) {
+    status = '완료';
+  } else if (selectedQuestionIds.length > 0) {
+    status = '중';
+  }
 
   const handleRetrospectiveComplete = () => {
     setIsRetrospectiveDone(true);

--- a/src/components/retrospective/FixedFooter.tsx
+++ b/src/components/retrospective/FixedFooter.tsx
@@ -37,6 +37,7 @@ export default function FixedFooter({
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   const handleComplete = async () => {
+    if (isRefreshing) return;
     // answerId가 없는 값이 있으면 요청을 보내지 않음
     const invalidAnswers = answers.filter((a) => typeof a.answerId !== 'number' || Number.isNaN(a.answerId));
     if (invalidAnswers.length > 0) {
@@ -103,7 +104,7 @@ export default function FixedFooter({
             updateAllAnswersMutation.isPending ||
             updateAnswerMutation.isPending ||
             markPRAsDoneMutation.isPending ||
-            isRefreshing
+            isRefreshing // 이 값이 true면 버튼 비활성화
           }
         >
           {isRefreshing ? '새로고침 중...' : '회고완료'}


### PR DESCRIPTION
<!--
# For Maintainers

- 최소한의 설명(팀에 속하지 않은 사람에게 PR을 이해하도록 설명하는 것을 목표로 합니다.)
- 코드 변경사항의 논리를 PR 리뷰어에게 설명하기 위해 필요한 경우 해당 코드 라인에 Review Comment를 추가합니다.
-->

## What?

- 한 번 '회고 완료' 상태에 들어가면 계속 '회고 완료' 표시 되도록 한다. 

## Why?

- PR preview 페이지 대신, 하나의 PR 페이지에서 내용 확인 + 수정이 모두 이루어지는데, 이 때 '수정 중'인 상태이더라도 '회고 완료'로 표시되도록 한다 

## How?

- 

## Check List

- [x] Merge 할 브랜치가 올바른가?
